### PR TITLE
Add Japan travel guide blog post

### DIFF
--- a/content/blog/japan-guide.mdx
+++ b/content/blog/japan-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Japan: A First-Timer's Guide (Tokyo, Kyoto, Osaka)"
 description: "Everything I wish I knew before going — logistics, itinerary, food, and shopping from my 10-day trip through Tokyo, Kyoto, and Osaka."
-date: "2024-12-10"
+date: "2026-03-28"
 tags: ["travel", "japan", "guide"]
 ---
 

--- a/content/blog/japan-guide.mdx
+++ b/content/blog/japan-guide.mdx
@@ -1,0 +1,184 @@
+---
+title: "Japan: A First-Timer's Guide (Tokyo, Kyoto, Osaka)"
+description: "Everything I wish I knew before going — logistics, itinerary, food, and shopping from my 10-day trip through Tokyo, Kyoto, and Osaka."
+date: "2024-12-10"
+tags: ["travel", "japan", "guide"]
+---
+
+Japan is the best trip I've ever taken. The food is ridiculous, the cities are immaculate, everything runs on time, and there's somehow always something new around the corner. This is the guide I put together for my friends — practical, opinionated, and based on what actually worked.
+
+---
+
+## Before You Go
+
+Three things to handle before you land:
+
+**1. Visit Japan Web** — Fill out your immigration and customs forms in advance at [services.digital.go.jp](https://services.digital.go.jp/en/visit-japan-web/). You'll get a QR code to scan at the border and skip the paper forms entirely. Takes 10 minutes, saves you 30.
+
+**2. Carry your passport** — Tourists are legally required to have their passport on them at all times. Don't leave it at the Airbnb.
+
+**3. Get a Suica card** — Add a virtual Suica card to your Apple Wallet before you go and load it with some money. It works on essentially all trains, metros, and even most vending machines. This is the move — you'll use it constantly.
+
+---
+
+## Getting Around
+
+### Do You Need the JR Pass?
+
+Probably not. Use the [JR Pass fare calculator](https://www.jrpass.com/farecalculator) to check your specific itinerary. I didn't need one for my trip.
+
+### Key Routes
+
+**Narita Airport → Tokyo** — Take the Limousine Bus. Find the counters right after baggage claim, pay by credit card, and it drops you close to most hotels and Airbnbs. Easy.
+
+**Tokyo → Kyoto / Osaka** — Shinkansen (bullet train). Buy online or at any major metro station. Fast, comfortable, punctual.
+
+**Kyoto → Nara** — Also Shinkansen. Easy day trip.
+
+**Kyoto → Uji** — JR Nara Line, paid with Suica. Quick and cheap.
+
+**Kyoto → Tokyo (Return)** — Shinkansen to Shinagawa (easier transfer than Tokyo Central), then the Narita Express to the airport. Give yourself about 4 hours total.
+
+---
+
+## The Itinerary
+
+This is a 10-day route: 5 days Tokyo, 1 day Kyoto, 1 day Osaka, 1 day Uji + Kyoto, then home.
+
+### Days 1–2: Tokyo — Shinjuku & Shibuya
+
+Shinjuku is a great base. Start here.
+
+**Shinjuku**
+- Shinjuku Gyoen Garden — one of the best parks in Tokyo
+- Tokyo Metropolitan Government Building Observation Deck — free views of the city (closed weekends, go early)
+- Golden Gai and Omoide Yokocho — tiny alley bars and yakitori spots, best at night
+- Kabukicho — walk around at night, it's an experience
+- Donki (Don Quijote) and Takashimaya Times Square for shopping
+
+**Shibuya**
+- Shibuya Crossing — do it, everyone does it for a reason
+- Shibuya Sky — the rooftop observation deck is worth it
+- Meiji Jingu Shrine and Yoyogi Park — a good morning activity
+- Miyashita Park and Mega Donki for afternoon shopping
+- Hachikō Statue — right outside Shibuya Station, easy photo stop
+
+### Day 3: Tokyo — Harajuku
+
+- Takeshita-dori — the chaotic, colorful main street
+- Omotesando — the upscale version, great for window shopping
+- Cat Street — connects Harajuku to Shibuya, good for vintage and streetwear
+- Meji-dori
+
+### Day 4: Tokyo — Asakusa, Ueno, Akihabara
+
+**Asakusa** — Try to avoid weekends, gets very crowded
+- Sensō-ji Shrine — Tokyo's oldest and most iconic temple
+- Nakamise-dori — the shopping street leading up to the shrine
+- Tokyo Skytree — go up if you want the aerial view
+- Kappabashi Street — kitchen and cookware district, fun even if you don't buy anything
+- Hoppy Street — izakaya row, good for afternoon drinks
+
+**Ueno**
+- Ueno Park
+- Ameyoko Street — outdoor market, good for snacks and bargain shopping
+
+**Akihabara** (evening)
+- Electric Town — anime, gaming, electronics. Go if that's your thing, skip if it's not.
+
+### Day 5: Tokyo — Chuo, Roppongi, Ginza
+
+**Chuo**
+- Tsukiji Fish Market — go early. Breakfast of sushi and tamagoyaki here is non-negotiable.
+- Yurakucho Izakaya Alley — lunch under the train tracks
+
+**Roppongi**
+- Tokyo Tower and Zojoji Temple at its base — great combo, especially at dusk
+- Roppongi Hills Mori Tower City View — solid observation deck
+
+**Ginza** (opens late, plan accordingly)
+- The biggest UNIQLO in the world
+- Muji flagship store
+- Flagship Onitsuka Tiger store (the red one)
+- Itoya — the best stationery store you'll ever visit
+
+### Day 7: Kyoto — East Kyoto
+
+- **Kiyomizu-dera** — opens at 6am, go before 8am to beat the crowds. The walk up through Sannenzaka is half the experience.
+- **Gion** — the old geisha district. Walk around in the evening for the best atmosphere and a chance to spot a geisha.
+- Philosopher's Path — especially good in early December
+- Eikando Zenrinji and Silver Pavilion (open 8:30am–5pm)
+- Ninenzaka, Sannenzaka, Nene-no-michi, and Ishibei-koji lane — all walkable from each other
+
+### Day 8: Osaka
+
+Osaka is the food city. Plan accordingly.
+
+**Must-eat**
+- Okonomiyaki — savory pancake, get it here, it's Osaka's thing
+- Kushi Katsu — deep-fried skewers, everywhere, all good
+- 551 Horai — pork buns and gyoza. There's almost always a line.
+- Rikuro Cheesecake — the jiggly one, buy it fresh
+
+**Landmarks**
+- Osaka Castle — the exterior is beautiful, skip the interior museum
+- Dotonbori at night — the neon river walk with the Glico man sign, street food, izakayas
+- Umeda Sky Building — great views
+- Shinsekai — old-school neighborhood, feels like a different era
+
+### Day 9: Uji + Central Kyoto
+
+**Morning: Uji**
+- Byodo-in Temple — beautiful, photogenic, uncrowded
+- Matcha everything — Nakamura Tokichi for matcha parfait, Tsuen Main Branch for tea
+
+**Afternoon: Central Kyoto**
+- Nishiki Market — Kyoto's covered food market, arrive before the lunch rush
+- Fushimi Inari — open 24 hours, go early morning or late evening to beat the crowds. The thousand torii gates are as good as they look.
+- Pontocho Alley — narrow lantern-lit dining alley along the river, dinner here
+
+---
+
+## Food
+
+The short version: eat everything. Even convenience stores are good.
+
+**Can't miss**
+- **Ramen** — Skip the tourist spots, find a hole in the wall. Ichiran is fine for the experience but not the best bowl you'll have.
+- **Udon** — Udon Shin and Menchirashi are both excellent
+- **Omakase** — Shibuya Sushi Labo was one of the best meals of my life
+- **Revolving sushi** — Hama-sushi, Sushi-ro, or Kura for cheap, quality kaiten-zushi
+- **Tsukemen** — dipping ramen, try it if you haven't
+- **Soba** — Kanda Matsuya in Tokyo or anywhere in Omoide Yokocho
+- **Omurice** — Kichi Kichi in Kyoto, the chef does a whole show at your table
+- **Onigiri** — Onigiri Gorichan in Osaka is legitimately great
+
+**Convenience store essential**
+- Japanese sandos from 7-Eleven — egg salad, tuna, katsu. Better than they have any right to be.
+- Fried chicken from Family Mart
+
+**Osaka specifically**
+- Japanese curry at Oretachino-curry ya
+- 551 Horai for dumplings (bao)
+
+Check my [Beli](https://beliapp.co/app/amolb) for specific restaurant ratings and notes from the trip.
+
+---
+
+## Shopping
+
+- **Clothes** — GU (Uniqlo's budget sister brand, incredible value), UNIQLO Ginza flagship
+- **Shoes** — Onitsuka Tiger (the flagship red store in Ginza), ABC Mart for variety
+- **Everything else** — Donki (Don Quijote) for snacks, souvenirs, random finds at midnight
+
+---
+
+## A Few Final Notes
+
+- Google Maps works great for transit directions in Japan
+- Cash is still king in many places — get some yen at the airport ATM when you land
+- Convenience stores (konbini) are genuinely good for meals, not just snacks
+- People are incredibly kind and helpful even with the language barrier
+- Buy one more thing than you think you need — luggage space is the only real regret
+
+Go. You won't be disappointed.

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -40,7 +40,7 @@ export function getAllPosts(): BlogPost[] {
       } as BlogPost;
     })
     .filter((p) => !p.draft)
-    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
   return posts;
 }

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -40,7 +40,7 @@ export function getAllPosts(): BlogPost[] {
       } as BlogPost;
     })
     .filter((p) => !p.draft)
-    .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 
   return posts;
 }


### PR DESCRIPTION
## Summary
- Adds `content/blog/japan-guide.mdx` — a 10-day Japan trip guide covering Tokyo, Kyoto, and Osaka
- Includes sections: Before You Go, Getting Around, Itinerary (Days 1–9), Food, Shopping, Final Notes
- Written in first-person casual tone, dated 2024-12-10, tagged `travel`, `japan`, `guide`

## Test plan
- [ ] Visit `/blog` — confirm the Japan guide appears in the post list with correct date and description
- [ ] Click into the post — verify all sections render correctly (headings, lists, links, horizontal rules)
- [ ] Check the Beli link in the Food section is clickable and points to the right profile
- [ ] Verify the post shows up as one of the 3 latest posts on the homepage if it's within the top 3 by date

🤖 Generated with [Claude Code](https://claude.com/claude-code)