### PR TITLE
Add blog post: 2026 March Madness recap

### DIFF
--- a/content/blog/march-madness-2026.mdx
+++ b/content/blog/march-madness-2026.mdx
@@ -1,0 +1,80 @@
+---
+title: "Michigan's March"
+description: "How the Wolverines won the 2026 NCAA Tournament, UConn's stunning buzzer-beater over Duke, and why Cal still can't catch a break."
+date: "2026-04-09"
+tags: ["sports", "basketball", "march madness"]
+---
+
+Michigan just won the national championship. First title since 1989. Built entirely on transfers. And they made it look easy.
+
+This was a great tournament — one of the better ones in recent memory. A buzzer-beater for the ages, a historically dominant champion, and enough chaos to keep things interesting. Here's how it went down.
+
+---
+
+## The Game Everyone Will Remember
+
+Before we get to Michigan, we have to talk about UConn vs. Duke.
+
+March 29. Elite Eight. Duke was the top overall seed in the tournament. They led by 19 in the first half. At halftime, the game was over — at least that's what everyone thought.
+
+It wasn't.
+
+UConn clawed back. Slowly, then all at once. With 0.4 seconds left, freshman Braylon Mullins stole the ball and buried a 35-foot three-pointer to give the Huskies a 73-72 win. The building lost its mind. Duke, a program that had never lost an NCAA tournament game when leading by 15+ at halftime — 134-0 all time — finally did.
+
+Mullins' shot was one of those moments that reminds you why March exists. A 19-point comeback in the Elite Eight, capped by a heave from near halfcourt. Instant classic.
+
+It also continued what's becoming a painful pattern for Duke. Second straight tournament ending in a massive collapse. At some point, that stops being bad luck.
+
+---
+
+## The Final Four
+
+**Michigan 91, Arizona 73**
+
+No drama here. Michigan was just better. The Wolverines were the No. 1 seed and played like it — imposing their size at the rim, controlling tempo, and making Arizona look like they didn't belong on the same court. A 18-point win in a Final Four game is a statement.
+
+**UConn 72, Illinois (No. 3 seed)**
+
+Coming off the emotional high of the Duke game, UConn handled Illinois. Tarris Reed Jr. and Braylon Mullins did most of the damage offensively. The Huskies were efficient, composed, and clearly riding momentum from one of the best wins in tournament history.
+
+---
+
+## The Final: Michigan 69, UConn 63
+
+Michigan was the better team for most of the championship game. Elliott Cadeau led the way with 19 points, including clutch plays down the stretch when UConn tried to make it interesting. The Wolverines never really looked in danger.
+
+It's Michigan's second national championship ever, and first in 37 years. That context matters — this isn't a blue blood program that collects titles. This was a program that had to claw its way back.
+
+---
+
+## How Michigan Actually Did This
+
+The story of this team is Dusty May and the transfer portal.
+
+May took over a program that needed a rebuild and did something that had literally never been done before: he fielded a starting five made up entirely of transfers. Yaxel Lindeborg, Elliott Cadeau, and three others — all transfers, all bought in, all bought into something bigger than their previous stops.
+
+The result? 37 wins. A national championship. And the first all-transfer starting five to ever win the title in NCAA history.
+
+College basketball's transfer portal era gets a lot of criticism — roster turnover, loyalty questions, programs hollowed out. Michigan just made the argument for the other side. May identified players who were underused or misused elsewhere, built a culture around them, and won a championship. That's a hell of a counter-argument.
+
+---
+
+## Cal: So Close, So Far
+
+I have to mention Cal, because as a Bay Area person, it stings.
+
+The Bears went 21-11 — their first 20-win season since 2017. They played eight NCAA tournament teams and went 4-4 against them. By most measures, it was a genuinely good year.
+
+But not good enough.
+
+Cal didn't get an NCAA bid. They ended up in the NIT, their first postseason appearance since 2017. The committee put them outside the last four in — meaning they weren't even technically a bubble team, they just missed.
+
+Four wins against tournament teams and you can't get in. That's the ACC for you. Cal moved conferences and immediately landed in one of the toughest brackets in college basketball. It's going to take more than one good season to consistently break through. The talent pipeline is there. The direction is right. But 2026 wasn't the year.
+
+Maybe next year.
+
+---
+
+Michigan earned it. The transfer portal storyline is compelling, May's coaching was elite, and the tournament gave us at least one all-timer moment. Mullins' shot alone was worth the whole month of basketball.
+
+See you in 2027.


### PR DESCRIPTION
## Summary
- New blog post: `content/blog/march-madness-2026.mdx`
- Covers Michigan's championship win over UConn (69-63), the UConn vs Duke Elite Eight buzzer-beater, Final Four results, Michigan's all-transfer roster story, and Cal's NIT finish

## What to visually check
- Blog index page shows the new post with correct title, description, and date
- Post renders correctly at `/blog/march-madness-2026` — headings, sections, and spacing look right
- Tags display correctly (sports, basketball, march madness)

🤖 Generated with [Claude Code](https://claude.ai/code)